### PR TITLE
Improve 'find' command

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,13 @@
+---
+engines:
+    coverage:
+        exclude_paths:
+            - src/dusql/closure.c
+            - src/dusql/_version.py
+            - test/**
+            - setup.py
+            - versioneer.py
+exclude_paths:
+    - src/dusql/closure.c
+    - src/dusql/_version.py
+    - versioneer.py

--- a/README.rst
+++ b/README.rst
@@ -33,10 +33,10 @@ Find files under ``$DIR``::
 
 TODO:
 
-* Add tests
 * Add check reports
-* Handle multiple paths
-* Automatically scan path if not in database
-* Update scans, handle deleted files
+* Handle multiple paths in cli arguments
+* Update scans, handle deleted files and changed sizes
 * Change database path (presently it creates `dusql.sqlite` in the current directory)
 * Progressively add results to database during the scan
+* Add more find arguments, e.g. size, mode
+

--- a/src/dusql/cli.py
+++ b/src/dusql/cli.py
@@ -52,9 +52,9 @@ class Find:
     def init_parser(self, parser):
         parser.add_argument('path',metavar='PATH',help="Path to search under")
         parser.add_argument('--older_than','--older-than',metavar='AGE',type=pandas.to_timedelta,help="Minimum age (e.g. '1y', '30d')")
-        parser.add_argument('--user',help="Match only this user id")
-        parser.add_argument('--group',help="Match only this group id")
-        parser.add_argument('--exclude',help="Exclude files and directories matching this name")
+        parser.add_argument('--user',help="Match only this user id",action='append')
+        parser.add_argument('--group',help="Match only this group id",action='append')
+        parser.add_argument('--exclude',help="Exclude files and directories matching this name",action='append')
 
     def call(self, args):
         from .find import find

--- a/src/dusql/cli.py
+++ b/src/dusql/cli.py
@@ -17,9 +17,13 @@ from __future__ import print_function
 
 import argparse
 import logging
+import pandas
 from . import db
 
+
 class Scan:
+    """
+    """
     def init_parser(self, parser):
         parser.add_argument('path')
 
@@ -30,6 +34,8 @@ class Scan:
 
 
 class Report:
+    """
+    """
     def init_parser(self, parser):
         parser.add_argument('path')
 
@@ -40,12 +46,15 @@ class Report:
 
 
 class Find:
+    """
+    Find the full path of files in the database
+    """
     def init_parser(self, parser):
-        parser.add_argument('path')
-        parser.add_argument('--older_than','--older-than')
-        parser.add_argument('--user')
-        parser.add_argument('--group')
-        parser.add_argument('--exclude')
+        parser.add_argument('path',metavar='PATH',help="Path to search under")
+        parser.add_argument('--older_than','--older-than',metavar='AGE',type=pandas.to_timedelta,help="Minimum age (e.g. '1y', '30d')")
+        parser.add_argument('--user',help="Match only this user id")
+        parser.add_argument('--group',help="Match only this group id")
+        parser.add_argument('--exclude',help="Exclude files and directories matching this name")
 
     def call(self, args):
         from .find import find
@@ -72,7 +81,7 @@ def main():
     logging.basicConfig()
 
     for name, c in commands.items():
-        p = subp.add_parser(name)
+        p = subp.add_parser(name, description=c.__doc__)
         p.set_defaults(func = c.call)
         c.init_parser(p)
 

--- a/src/dusql/cli.py
+++ b/src/dusql/cli.py
@@ -35,7 +35,7 @@ def parse_size(size):
         'G': 1073741824,
         }
     m = re.fullmatch(r'(?P<size>[+-]?\d+(\.\d*)?)(?P<unit>[cwbkMG])', size)
-    
+
     if m is None:
         raise Exception(f"Could not interpret '{size}' as a size")
 

--- a/src/dusql/cli.py
+++ b/src/dusql/cli.py
@@ -45,11 +45,12 @@ class Find:
         parser.add_argument('--older_than','--older-than')
         parser.add_argument('--user')
         parser.add_argument('--group')
+        parser.add_argument('--exclude')
 
     def call(self, args):
         from .find import find
         conn = db.connect()
-        q = find(args.path, conn, older_than=args.older_than, user=args.user, group=args.group)
+        q = find(args.path, conn, older_than=args.older_than, user=args.user, group=args.group, exclude=args.exclude)
         results = conn.execute(q)
 
         for r in results:

--- a/src/dusql/cli.py
+++ b/src/dusql/cli.py
@@ -76,7 +76,7 @@ class Find:
         parser.add_argument('--user',help="Match only this user id",action='append')
         parser.add_argument('--group',help="Match only this group id",action='append')
         parser.add_argument('--exclude',help="Exclude files and directories matching this name",action='append')
-        parser.add_argument('--size',type=parse_size,help="Find-style size to match (e.g. '20G')")
+        parser.add_argument('--size',type=parse_size,help="Match files greater than this find-style size (e.g. '20G') (prefix with '-' for less than)")
 
     def call(self, args):
         from .find import find

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -16,7 +16,7 @@
 from __future__ import print_function
 
 from . import model
-from .scan import scan
+from .scan import autoscan
 
 import sqlalchemy as sa
 import pandas
@@ -46,13 +46,7 @@ import os
 
 
 def find(path, connection, older_than=None, user=None, group=None):
-    if path is not None:
-        path_inode = os.stat(path).st_ino
-        q = sa.sql.select([model.paths.c.id]).where(model.paths.c.inode == path_inode)
-        r = connection.execute(q).scalar()
-        if r is None:
-            scan(path, connection)
-
+    autoscan(path, connection)
 
     target_path = sa.sql.alias(model.paths, 'target_path')
     parent_path = sa.sql.alias(model.paths, 'parent_path')

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -47,8 +47,7 @@ def find(path, connection, older_than=None, user=None, group=None, exclude=None)
         q = q.select_from(j).where(parent_path.c.parent_inode == path_inode)
 
     if older_than is not None:
-        delta = pandas.to_timedelta(older_than)
-        ts = (pandas.Timestamp.now(tz='UTC') - delta)
+        ts = (pandas.Timestamp.now(tz='UTC') - older_than)
         ts = ts.timestamp()
         q = q.where(model.paths.c.mtime < ts)
 

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -25,7 +25,7 @@ import grp
 import os
 
 
-def find(path, connection, older_than=None, user=None, group=None, exclude=None):
+def find(path, connection, older_than=None, user=None, group=None, exclude=None, size=None):
     autoscan(path, connection)
 
     j = (model.paths_fullpath
@@ -63,5 +63,11 @@ def find(path, connection, older_than=None, user=None, group=None, exclude=None)
                     .join(model.paths, model.paths.c.id == model.paths_parents.c.parent_id))
                 .where(model.paths.c.name.in_(exclude)))
         q = q.where(~model.paths.c.id.in_(excl_q))
+
+    if size is not None:
+        if size > 0:
+            q = q.where(model.paths.c.size >= size)
+        else:
+            q = q.where(model.paths.c.size < -size)
 
     return q

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -25,7 +25,7 @@ import grp
 import os
 
 
-def find(path, connection, older_than=None, user=None, group=None, exclude_dir=None):
+def find(path, connection, older_than=None, user=None, group=None, exclude=None):
     autoscan(path, connection)
 
     j = (model.paths_fullpath
@@ -57,5 +57,12 @@ def find(path, connection, older_than=None, user=None, group=None, exclude_dir=N
 
     if group is not None:
         q = q.where(model.paths.c.uid == grp.getgrnam(group).gr_gid)
+
+    if exclude is not None:
+        excl_q = (sa.select([model.paths_parents.c.path_id])
+                .select_from(model.paths_parents
+                    .join(model.paths, model.paths.c.id == model.paths_parents.c.parent_id))
+                .where(model.paths.c.name == exclude))
+        q = q.where(~model.paths.c.id.in_(excl_q))
 
     return q

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -52,16 +52,16 @@ def find(path, connection, older_than=None, user=None, group=None, exclude=None)
         q = q.where(model.paths.c.mtime < ts)
 
     if user is not None:
-        q = q.where(model.paths.c.uid == pwd.getpwnam(user).pw_uid)
+        q = q.where(model.paths.c.uid.in_([pwd.getpwnam(u).pw_uid for u in user]))
 
     if group is not None:
-        q = q.where(model.paths.c.uid == grp.getgrnam(group).gr_gid)
+        q = q.where(model.paths.c.uid.in_([grp.getgrnam(g).gr_gid for g in group]))
 
     if exclude is not None:
         excl_q = (sa.select([model.paths_parents.c.path_id])
                 .select_from(model.paths_parents
                     .join(model.paths, model.paths.c.id == model.paths_parents.c.parent_id))
-                .where(model.paths.c.name == exclude))
+                .where(model.paths.c.name.in_(exclude)))
         q = q.where(~model.paths.c.id.in_(excl_q))
 
     return q

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -24,68 +24,27 @@ import pwd
 import grp
 import os
 
-# SELECT full_path.path
-# FROM (
-#   SELECT
-#     expanded_parent.inode AS inode,
-#     group_concat(expanded_parent.name, '/') AS path
-#   FROM (
-#     SELECT
-#       target_path.inode AS inode,
-#       paths_closure.depth AS depth,
-#       parent_path.name AS name
-#     FROM paths AS target_path
-#     JOIN paths_closure ON target_path.inode = paths_closure.root
-#     JOIN paths AS parent_path ON parent_path.inode = paths_closure.id
-#     WHERE paths_closure.idcolumn = 'parent_inode'
-#       AND paths_closure.parentcolumn = 'inode'
-#     ORDER BY target_path.inode, paths_closure.depth DESC
-#   ) AS expanded_parent
-#   GROUP BY expanded_parent.inode
-# ) AS full_path
 
-
-def find(path, connection, older_than=None, user=None, group=None):
+def find(path, connection, older_than=None, user=None, group=None, exclude_dir=None):
     autoscan(path, connection)
 
-    target_path = sa.sql.alias(model.paths, 'target_path')
-    parent_path = sa.sql.alias(model.paths, 'parent_path')
-    parent_closure = sa.sql.alias(model.paths_closure, 'parent_closure')
+    j = (model.paths_fullpath
+        .join(model.paths, model.paths.c.id == model.paths_fullpath.c.path_id))
 
-    # Create a view 'path.id','depth','parent_path.name' to construct full paths
-    j = (sa.sql.join(target_path, parent_closure, target_path.c.parent_inode == parent_closure.c.root)
-            .join(parent_path, parent_path.c.inode == parent_closure.c.id))
     q = (sa.sql.select([
-            target_path.c.id,
-            target_path.c.name,
-            parent_closure.c.depth,
-            parent_path.c.name.label('path_fragment'),
+            model.paths_fullpath.c.path,
         ])
         .select_from(j)
-        .where(parent_closure.c.idcolumn == 'parent_inode')
-        .where(parent_closure.c.parentcolumn == 'inode')
-        .order_by(target_path.c.inode, parent_closure.c.depth.desc())
-        .alias('expanded_parent'))
-
-    # Group all the parent path components into a file path for each target
-    full_path = (sa.sql.select([
-          q.c.id,
-          (sa.sql.expression.func.group_concat(q.c.path_fragment,'/') + '/' + q.c.name).label('path'),
-        ])
-        .select_from(q)
-        .group_by(q.c.id)
-        .alias('full_path'))
-
-    # Join the full paths back to the path table for further filtering
-    j = sa.sql.join(model.paths, full_path, model.paths.c.id == full_path.c.id)
-    q = sa.sql.select([
-        full_path.c.path,
-        ]).select_from(j)
+        )
 
     if path is not None:
         path_inode = os.stat(path).st_ino
-        j = sa.sql.join(j, model.paths_closure, model.paths.c.parent_inode == model.paths_closure.c.id)
-        q = q.select_from(j).where(model.paths_closure.c.root == path_inode)
+        parent_path = sa.alias(model.paths)
+
+        j = (j.join(model.paths_parents, model.paths.c.id == model.paths_parents.c.path_id)
+                .join(parent_path, parent_path.c.id == model.paths_parents.c.parent_id))
+
+        q = q.select_from(j).where(parent_path.c.parent_inode == path_inode)
 
     if older_than is not None:
         delta = pandas.to_timedelta(older_than)

--- a/src/dusql/model.py
+++ b/src/dusql/model.py
@@ -28,6 +28,7 @@ paths = sa.Table('paths', metadata,
         sa.Column('parent_inode',sa.Integer,sa.ForeignKey('paths.inode'),index=True),
         sa.Column('uid', sa.Integer),
         sa.Column('gid', sa.Integer),
+        sa.UniqueConstraint('inode','parent_inode',name='uniq_inode'),
         )
 
 paths_closure = closure_table('paths_closure', metadata,

--- a/src/dusql/report.py
+++ b/src/dusql/report.py
@@ -16,6 +16,7 @@
 from __future__ import print_function
 
 from . import model
+from .scan import autoscan
 import sqlalchemy as sa
 import sqlalchemy.sql.functions as safunc
 import pwd
@@ -25,6 +26,8 @@ import os
 
 
 def report(path, connection):
+    autoscan(path, connection)
+
     total = (sa.sql.select([
         model.paths.c.uid,
         model.paths.c.gid,

--- a/src/dusql/scan.py
+++ b/src/dusql/scan.py
@@ -53,7 +53,6 @@ def scan(path, connection):
     Recursively scan all paths under ``path``, adding their metadata to the
     database
     """
-    parent_inode = os.stat(path).st_ino
 
     with tqdm.tqdm(desc="Directories Scanned") as pbar:
         records = list(_walk_generator(path, progress=pbar))

--- a/src/dusql/scan.py
+++ b/src/dusql/scan.py
@@ -16,6 +16,7 @@
 from __future__ import print_function
 
 from .model import paths as paths_table
+from .upsert_ext import Insert
 import tqdm
 import os
 
@@ -55,5 +56,6 @@ def scan(path, connection):
 
     with tqdm.tqdm(desc="Directories Scanned") as pbar:
         records = list(_walk_generator(path, progress=pbar))
+        stmt = Insert(paths_table).values(records).on_conflict_do_nothing(index_elements=[paths_table.c.inode, paths_table.c.parent_inode])
 
-        connection.execute(paths_table.insert(), records)
+        connection.execute(stmt)

--- a/src/dusql/scan.py
+++ b/src/dusql/scan.py
@@ -53,6 +53,7 @@ def scan(path, connection):
     Recursively scan all paths under ``path``, adding their metadata to the
     database
     """
+    parent_inode = os.stat(path).st_ino
 
     with tqdm.tqdm(desc="Directories Scanned") as pbar:
         records = list(_walk_generator(path, progress=pbar))

--- a/src/dusql/upsert_ext.py
+++ b/src/dusql/upsert_ext.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# Copyright 2019 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from sqlalchemy.sql import dml, schema
+from sqlalchemy.ext import compiler
+
+class Insert(dml.Insert):
+    """
+    Custom Sqlalchemy Insert class to handle SQLite upserts
+
+    https://www.sqlite.org/lang_UPSERT.html
+
+    Very basic re-implementation of the Sqlalchemy postgres upsert
+    """
+
+    def on_conflict_do_nothing(self, index_elements):
+        self._post_values_clause = OnConflictDoNothing(index_elements)
+        return self
+
+class OnConflictDoNothing(schema.ClauseElement):
+    def __init__(self, index_elements=None):
+        self.index_elements = index_elements
+
+@compiler.compiles(OnConflictDoNothing)
+def compile_do_nothing(element, compiler, **kw):
+    conflict_target = ''
+
+    if element.index_elements is not None:
+        index_columns = [compiler.process(i, **kw) for i in element.index_elements]
+        conflict_target = f'({",".join(index_columns)})'
+
+    return f'ON CONFLICT {conflict_target} DO NOTHING'

--- a/src/dusql/view_ext.py
+++ b/src/dusql/view_ext.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Copyright 2019 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from sqlalchemy.schema import DDLElement
+from sqlalchemy.sql import table
+from sqlalchemy.ext import compiler
+from sqlalchemy import event
+
+class CreateView(DDLElement):
+    def __init__(self, name, selectable):
+        self.name = name
+        self.selectable = selectable
+
+
+@compiler.compiles(CreateView)
+def compile_create_view(element, compiler, **kw):
+    selectable = compiler.sql_compiler.process(element.selectable, literal_binds=True)
+    return f'CREATE VIEW {element.name} AS {selectable}'
+
+
+def should_create_view(ddl, target, bind, **kw):
+    row = bind.execute("SELECT name FROM sqlite_master WHERE type='view' AND name=?",
+            ddl.name).scalar()
+    return not bool(row)
+
+
+def view(name, metadata, selectable):
+    t = table(name)
+
+    for c in selectable.c:
+        c._make_proxy(t)
+
+    event.listen(metadata,
+            'after_create',
+            CreateView(name, selectable)
+            .execute_if(callable_=should_create_view))
+
+    return t

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,8 @@ import pytest
 
 from dusql.db import connect
 from dusql.scan import scan
+import os
+
 
 @pytest.fixture
 def conn():
@@ -42,3 +44,12 @@ def sample_data(tmp_path_factory):
 def sample_db(conn, sample_data):
     scan(sample_data, conn)
 
+
+def count_files(path):
+    """
+    Count the number of paths under a directory
+    """
+    count = 0
+    for p in os.walk(path):
+        count+=1
+    return count-1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -54,10 +54,11 @@ def sample_db(conn, sample_data):
 
 def count_files(path):
     """
-    Count the number of paths under a directory
+    Count the number of paths under ``path``, excluding itself
     """
     count = 0
     for p, ds, fs in os.walk(path):
-        print(p)
+        for f in fs:
+            print(os.path.join(p,f))
         count += 1 + len(fs)
-    return count-1
+    return count - 1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,6 +37,13 @@ def sample_data(tmp_path_factory):
     for p in [a,b,c,d]:
         p.mkdir()
 
+    # Create a hard link
+    e = d / 'e'
+    e.touch()
+
+    f = b / 'f'
+    os.link(e, f)
+
     return root
 
 
@@ -50,6 +57,7 @@ def count_files(path):
     Count the number of paths under a directory
     """
     count = 0
-    for p in os.walk(path):
-        count+=1
+    for p, ds, fs in os.walk(path):
+        print(p)
+        count += 1 + len(fs)
     return count-1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -57,7 +57,7 @@ def count_files(path):
     Count the number of paths under ``path``, excluding itself
     """
     count = 0
-    for p, ds, fs in os.walk(path):
+    for p, _, fs in os.walk(path):
         for f in fs:
             print(os.path.join(p,f))
         count += 1 + len(fs)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,6 +24,7 @@ import os
 @pytest.fixture
 def conn():
     return connect('sqlite:///:memory:', echo=False)
+    #return connect('sqlite:///test.sqlite', echo=False)
 
 
 @pytest.fixture(scope="session")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Copyright 2019 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from dusql.cli import *
+
+def test_parse_size():
+    assert parse_size('10k') == 10240
+    assert parse_size('-10k') == -10240
+    assert parse_size('1.5k') == 1024+512

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -17,8 +17,6 @@
 from dusql.find import *
 from dusql import model
 
-import sqlalchemy as sa
-
 from conftest import count_files
 
 

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -33,7 +33,10 @@ def test_find_all(conn, sample_db, sample_data):
     # Find all files in the DB
     q = find(path=None, connection=conn)
     results = conn.execute(q)
-    assert len(list(results)) == count_files(sample_data)
+
+    paths = [r.path for r in results]
+
+    assert len(paths) == count_files(sample_data) - 1
 
 
 def test_find_subtree(conn, sample_data, sample_db):
@@ -41,3 +44,10 @@ def test_find_subtree(conn, sample_data, sample_db):
     q = find(path=sample_data / 'a' / 'c', connection=conn)
     results = conn.execute(q)
     assert len(list(results)) == count_files(sample_data / 'a' / 'c')
+
+
+def test_autoscan(conn, sample_data):
+    # Should automatically scan the path
+    q = find(path=sample_data, connection=conn)
+    results = conn.execute(q)
+    assert len(list(results)) == count_files(sample_data) - 1

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -60,8 +60,8 @@ def test_autoscan(conn, sample_data):
 
 def test_exclude(conn, sample_data, sample_db):
     # Find all files except those under 'a/c'
-    q = find(sample_data, conn, exclude_dir='c')
+    q = find(sample_data, conn, exclude='c')
     results = [r.path for r in conn.execute(q)]
     assert 'a/c' not in results
     assert 'a/c/d/e' not in results
-    assert len(results) == count_files(sample_data) - count_files(sample_data / 'a' / 'c')
+    assert len(results) == count_files(sample_data) - count_files(sample_data / 'a' / 'c') - 1

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -19,6 +19,8 @@ from dusql import model
 
 import sqlalchemy as sa
 
+from conftest import count_files
+
 
 def test_find_empty(conn):
     # Empty DB has no files
@@ -27,15 +29,15 @@ def test_find_empty(conn):
     assert len(list(results)) == 0
 
 
-def test_find_all(conn, sample_db):
+def test_find_all(conn, sample_db, sample_data):
     # Find all files in the DB
     q = find(path=None, connection=conn)
     results = conn.execute(q)
-    assert len(list(results)) == 4
+    assert len(list(results)) == count_files(sample_data)
 
 
 def test_find_subtree(conn, sample_data, sample_db):
     # Find all files under 'a/c'
     q = find(path=sample_data / 'a' / 'c', connection=conn)
     results = conn.execute(q)
-    assert len(list(results)) == 2
+    assert len(list(results)) == count_files(sample_data / 'a' / 'c')

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# Copyright 2019 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from dusql.model import *
+
+import sqlalchemy as sa
+from conftest import count_files
+import os
+
+
+def test_paths_count(conn, sample_db, sample_data):
+    # There should be a paths and paths_fullpath row for each file
+    q = sa.select([sa.func.count()]).select_from(paths)
+    r = conn.execute(q).scalar()
+
+    assert r == count_files(sample_data)
+
+    q = sa.select([sa.func.count()]).select_from(paths_fullpath)
+    r = conn.execute(q).scalar()
+
+    assert r == count_files(sample_data)
+
+
+def test_paths_parents(conn, sample_db):
+    # Each path should have only one parent
+    q = (sa.select([paths_parents.c.path_id, sa.func.count().label('count')])
+            .where(paths_parents.c.depth == 0)
+            .group_by(paths_parents.c.path_id))
+
+    for r in conn.execute(q):
+        assert r.count == 1
+
+
+def test_paths_fullpath(conn, sample_db, sample_data):
+    # Make sure paths are correct
+    q = sa.select([paths_fullpath.c.path])
+    paths = [r.path for r in conn.execute(q)]
+
+    for p, _, fs in os.walk(sample_data):
+        relpath = os.path.relpath(p, sample_data)
+        if relpath == '.':
+            continue
+
+        assert relpath in paths
+
+        for f in fs:
+            assert os.path.join(relpath, f) in paths
+

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# Copyright 2019 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from dusql.report import report
+
+from dusql import model
+import sqlalchemy as sa
+
+def test_report(conn, sample_db, sample_data):
+    report(sample_data, conn)
+
+
+def test_autoscan(conn, sample_data):
+    report(sample_data, conn)
+
+    q = sa.select([model.paths.c.inode])
+    r = conn.execute(q)
+    assert len(list(r)) > 0

--- a/test/test_scan.py
+++ b/test/test_scan.py
@@ -14,13 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+from dusql.scan import scan
+
 from dusql import model
 import sqlalchemy as sa
 
+from conftest import count_files
 
-def test_scan_sample(conn, sample_db):
+
+def test_scan_sample(conn, sample_db, sample_data):
     # Check the scanned sample data
     q = sa.select([model.paths.c.inode])
     r = conn.execute(q)
-    assert len(list(r)) == 4
+    assert len(list(r)) == count_files(sample_data)
+
+
+def test_scan_twice(conn, sample_db, sample_data):
+    # Scanning the same directory twice should not change data
+    q = sa.select([model.paths.c.inode])
+    r = conn.execute(q)
+    assert len(list(r)) == count_files(sample_data)
+
+    scan(sample_data, conn)
+
+    q = sa.select([model.paths.c.inode])
+    r = conn.execute(q)
+    assert len(list(r)) == count_files(sample_data)
 

--- a/test/test_scan.py
+++ b/test/test_scan.py
@@ -27,6 +27,8 @@ def test_scan_sample(conn, sample_db, sample_data):
     # Check the scanned sample data
     q = sa.select([model.paths.c.inode])
     r = conn.execute(q)
+
+    # Note the root path is not included in the scan
     assert len(list(r)) == count_files(sample_data)
 
 


### PR DESCRIPTION
 - Properly handle hard links in `find` (only return the copy under the search path, not all copies)
 - Handle re-scanning the same directory (ignores the path if it exists in the DB, TODO: need to change to update)
 - Automatically scan the path if you try to `find` a path that doesn't exist (TODO: add to report as well)

Fixes #1 