### PR TITLE
Report using ncdu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
         - bash conda.sh -b -p ~/miniconda
-        - ~/miniconda/bin/conda config --system --add channels conda-forge
+        - ~/miniconda/bin/conda config --system --add channels conda-forge coecms
 install:
         - ~/miniconda/bin/conda install --yes conda-build conda-verify codacy-coverage
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
         - bash conda.sh -b -p ~/miniconda
-        - ~/miniconda/bin/conda config --system --add channels conda-forge coecms
+        - ~/miniconda/bin/conda config --system --add channels conda-forge
+        - ~/miniconda/bin/conda config --system --add channels coecms
 install:
         - ~/miniconda/bin/conda install --yes conda-build conda-verify codacy-coverage
 script:

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,5 @@ TODO:
 * Handle multiple paths in cli arguments
 * Update scans, handle deleted files and changed sizes
 * Change database path (presently it creates `dusql.sqlite` in the current directory)
-* Progressively add results to database during the scan
 * Add more find arguments, e.g. size, mode
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -19,6 +19,7 @@ requirements:
         - sqlalchemy
         - pandas
         - tqdm
+        - ncdu
 
 build:
     noarch: python

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -44,7 +44,7 @@ def find(path, connection, older_than=None, user=None, group=None, exclude=None,
         j = (j.join(model.paths_parents, model.paths.c.id == model.paths_parents.c.path_id)
                 .join(parent_path, parent_path.c.id == model.paths_parents.c.parent_id))
 
-        q = q.select_from(j).where(parent_path.c.parent_inode == path_inode)
+        q = q.select_from(j).where(parent_path.c.inode == path_inode)
 
     if older_than is not None:
         ts = (pandas.Timestamp.now(tz='UTC') - older_than)

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -24,7 +24,6 @@ import pandas
 import pwd
 import grp
 import os
-import json
 import stat
 from datetime import datetime
 

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -48,7 +48,7 @@ def to_ncdu(findq, connection):
             model.paths.c.mode,
             model.paths.c.uid,
             model.paths.c.gid,
-            model.paths.c.mtime,
+            sa.cast(model.paths.c.mtime, sa.Integer).label('mtime'),
             ])
             .select_from(model.paths
                 .join(model.paths_parents,
@@ -57,9 +57,10 @@ def to_ncdu(findq, connection):
             .distinct()
         )
 
-    tree = {None: [{"name": "/"}]}
+    tree = {None: [{"name": "."}]}
     for r in connection.execute(q):
         d = dict(r)
+        d['dsize'] = d['asize']
         i = d.pop('id')
         if stat.S_ISDIR(d['mode']):
             tree[i] = [d]

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -119,7 +119,7 @@ def find(path, connection, older_than=None, user=None, group=None, exclude=None,
         q = q.where(model.paths.c.uid.in_([pwd.getpwnam(u).pw_uid for u in user]))
 
     if group is not None:
-        q = q.where(model.paths.c.uid.in_([grp.getgrnam(g).gr_gid for g in group]))
+        q = q.where(model.paths.c.gid.in_([grp.getgrnam(g).gr_gid for g in group]))
 
     if exclude is not None:
         excl_q = (sa.select([model.paths_parents.c.path_id])

--- a/src/dusql/find.py
+++ b/src/dusql/find.py
@@ -17,12 +17,76 @@ from __future__ import print_function
 
 from . import model
 from .scan import autoscan
+from . import __version__
 
 import sqlalchemy as sa
 import pandas
 import pwd
 import grp
 import os
+import json
+import stat
+from datetime import datetime
+
+
+def to_ncdu(findq, connection):
+    """
+    Format the output of 'find' so it can be read by ``ncdu -e``
+    """
+
+    findq = findq.with_only_columns([model.paths.c.id])
+
+    paths_parents = sa.alias(model.paths_parents)
+
+    # Get the metadata needed by ncdu
+    # Found results, plus all of their parent paths
+    q = (sa.select([
+            model.paths.c.id,
+            model.paths.c.size.label('asize'),
+            model.paths.c.inode.label('ino'),
+            model.paths.c.name,
+            model.paths.c.mode,
+            model.paths.c.uid,
+            model.paths.c.gid,
+            model.paths.c.mtime,
+            ])
+            .select_from(model.paths
+                .join(model.paths_parents,
+                    model.paths_parents.c.parent_id == model.paths.c.id))
+            .where(model.paths_parents.c.path_id.in_(findq))
+            .distinct()
+        )
+
+    tree = {None: [{"name": "/"}]}
+    for r in connection.execute(q):
+        d = dict(r)
+        i = d.pop('id')
+        if stat.S_ISDIR(d['mode']):
+            tree[i] = [d]
+        else:
+            tree[i] = d
+
+    # Get the tree edges
+    q = (sa.select([
+            paths_parents.c.parent_id.label('id'),
+            model.paths_parent_id.c.parent_id,
+            ])
+            .select_from(paths_parents
+                .join(model.paths_parent_id,
+                    paths_parents.c.parent_id == model.paths_parent_id.c.id,
+                    isouter=True,
+                ))
+            .where(paths_parents.c.path_id.in_(findq))
+            .distinct()
+        )
+
+    # Construct the tree relationships
+    for r in connection.execute(q):
+        tree[r.parent_id].append(tree[r.id])
+
+    # Return the data ready to be converted to json
+    return [1,1,{"progname": "dusql","progver": __version__,
+        "timestamp": datetime.utcnow().timestamp()},tree[None]]
 
 
 def find(path, connection, older_than=None, user=None, group=None, exclude=None, size=None):

--- a/src/dusql/model.py
+++ b/src/dusql/model.py
@@ -57,10 +57,14 @@ paths = sa.Table('paths', metadata,
         sa.Column('inode',sa.Integer,index=True),
         sa.Column('size',sa.Integer),
         sa.Column('mtime',sa.Float),
+        sa.Column('ctime',sa.Float),
         sa.Column('parent_inode',sa.Integer,sa.ForeignKey('paths.inode'),index=True),
         sa.Column('uid', sa.Integer),
         sa.Column('gid', sa.Integer),
-        sa.UniqueConstraint('inode','parent_inode',name='uniq_inode'),
+        sa.Column('mode', sa.Integer),
+        sa.Column('device', sa.Integer),
+        sa.Column('last_seen',sa.Float),
+        sa.UniqueConstraint('inode','parent_inode','name',name='uniq_inode_edge'),
         )
 
 _other_paths = sa.sql.alias(paths)
@@ -120,7 +124,7 @@ _q = (sa.sql.select([
             paths
             .join(paths_parents, paths.c.id == paths_parents.c.parent_id)
         )
-        .order_by(paths.c.id, paths_parents.c.depth)
+        .order_by(paths_parents.c.path_id, paths_parents.c.depth.desc())
         )
 
 

--- a/src/dusql/scan.py
+++ b/src/dusql/scan.py
@@ -46,7 +46,7 @@ def _walk_generator(path, parent_inode=None, progress=None, scan_time=None):
     if parent_inode is None:
         parent_record = _single_file(path, scan_time)
         yield parent_record
-        parent_inode = parent_record['parent_inode']
+        parent_inode = parent_record['inode']
 
     for inode in os.scandir(path):
         # Loop over each file in the directory, adding it to the results list

--- a/src/dusql/scan.py
+++ b/src/dusql/scan.py
@@ -25,7 +25,7 @@ from datetime import datetime
 
 def _single_file(path, scan_time):
     name = os.path.basename(path)
-    parent_inode = -1
+    parent_inode = 0
     stat = os.stat(path)
     return _single_file_record(name, parent_inode, stat, scan_time)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -64,4 +64,5 @@ def count_files(path):
         for f in fs:
             print(os.path.join(p,f))
         count += 1 + len(fs)
+        print(p)
     return count

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,7 +43,9 @@ def sample_data(tmp_path_factory):
     e.touch()
 
     f = b / 'f'
+    g = b / 'g'
     os.link(e, f)
+    os.link(e, g)
 
     return root
 
@@ -55,11 +57,11 @@ def sample_db(conn, sample_data):
 
 def count_files(path):
     """
-    Count the number of paths under ``path``, excluding itself
+    Count the number of paths under ``path``
     """
     count = 0
     for p, _, fs in os.walk(path):
         for f in fs:
             print(os.path.join(p,f))
         count += 1 + len(fs)
-    return count - 1
+    return count

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -18,6 +18,10 @@ from dusql.find import *
 from dusql import model
 
 from conftest import count_files
+import os
+
+def to_relpath(path, base):
+    return os.path.relpath(base / path, base / '..')
 
 
 def test_find_empty(conn):
@@ -41,8 +45,8 @@ def test_find_subtree(conn, sample_data, sample_db):
     # Find all files under 'a/c'
     q = find(path=sample_data / 'a' / 'c', connection=conn)
     results = [r.path for r in conn.execute(q)]
-    assert 'a/c/d/e' in results
-    assert 'a/b/f' not in results
+    assert to_relpath('a/c/d/e', sample_data) in results
+    assert to_relpath('a/b/f', sample_data) not in results
     assert len(results) == count_files(sample_data / 'a' / 'c')
 
 
@@ -64,4 +68,4 @@ def test_exclude(conn, sample_data, sample_db):
     results = [r.path for r in conn.execute(q)]
     assert 'a/c' not in results
     assert 'a/c/d/e' not in results
-    assert len(results) == count_files(sample_data) - count_files(sample_data / 'a' / 'c') - 1
+    assert len(results) == count_files(sample_data) - count_files(sample_data / 'a' / 'c')

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -69,3 +69,13 @@ def test_exclude(conn, sample_data, sample_db):
     assert 'a/c' not in results
     assert 'a/c/d/e' not in results
     assert len(results) == count_files(sample_data) - count_files(sample_data / 'a' / 'c')
+
+
+def test_ncdu(conn, sample_data, sample_db):
+    q = find(sample_data/'a', conn)
+    ncdu = to_ncdu(q, conn)
+    print(ncdu)
+
+    assert ncdu[3][0]['name'] == '/'
+    assert ncdu[3][1][0]['name'] == sample_data.name
+    assert ncdu[3][1][1][0]['name'] == 'a'

--- a/test/test_find.py
+++ b/test/test_find.py
@@ -76,6 +76,6 @@ def test_ncdu(conn, sample_data, sample_db):
     ncdu = to_ncdu(q, conn)
     print(ncdu)
 
-    assert ncdu[3][0]['name'] == '/'
+    assert ncdu[3][0]['name'] == '.'
     assert ncdu[3][1][0]['name'] == sample_data.name
     assert ncdu[3][1][1][0]['name'] == 'a'

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -51,7 +51,7 @@ def test_paths_fullpath(conn, sample_db, sample_data):
     paths = [r.path for r in conn.execute(q)]
 
     for p, _, fs in os.walk(sample_data):
-        relpath = os.path.relpath(p, sample_data)
+        relpath = os.path.relpath(p, os.path.join(sample_data,'..'))
         if relpath == '.':
             continue
 

--- a/test/test_scan.py
+++ b/test/test_scan.py
@@ -34,13 +34,12 @@ def test_scan_sample(conn, sample_db, sample_data):
 
 def test_scan_twice(conn, sample_db, sample_data):
     # Scanning the same directory twice should not change data
-    q = sa.select([model.paths.c.inode])
+    q = sa.select([model.paths_fullpath.c.path])
     r = conn.execute(q)
     assert len(list(r)) == count_files(sample_data)
 
     scan(sample_data, conn)
 
-    q = sa.select([model.paths.c.inode])
+    q = sa.select([model.paths_fullpath.c.path])
     r = conn.execute(q)
     assert len(list(r)) == count_files(sample_data)
-

--- a/test/test_scan.py
+++ b/test/test_scan.py
@@ -43,3 +43,32 @@ def test_scan_twice(conn, sample_db, sample_data):
     q = sa.select([model.paths_fullpath.c.path])
     r = conn.execute(q)
     assert len(list(r)) == count_files(sample_data)
+
+
+def test_scan_root(conn, sample_db, sample_data):
+    # Get the root entry
+    q = (sa.select([
+        model.paths_fullpath.c.path,
+        model.paths.c.parent_inode,
+        model.paths.c.inode,
+        ])
+            .select_from(
+                model.paths_fullpath
+                .join(model.paths, model.paths.c.id == model.paths_fullpath.c.path_id))
+            .where(model.paths.c.inode == sample_data.stat().st_ino))
+
+    r = list(conn.execute(q))
+
+    assert r[0].parent_inode == 0
+    assert r[0].path == sample_data.name
+
+    root_inode = r[0].inode
+
+    q = (sa.select([
+            model.paths.c.parent_inode,
+            ])
+            .where(model.paths.c.inode == (sample_data / 'a').stat().st_ino))
+    r = conn.execute(q).scalar()
+
+    assert r == root_inode
+


### PR DESCRIPTION
Rather than a list of files, if there is an interactive terminal send the found files to ncdu for interactive navigation. A list is still used if you send the output to a pipe, or if it is run in a non-interactive context